### PR TITLE
KaText: accept themeFuncR

### DIFF
--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,39 +1,35 @@
 import styled from '@emotion/styled'
 
 import { HTMLAttributes, ReactElement, ReactNode } from 'react'
-import { themeFunc, font, KaFontType } from '../../styles'
+import { themeFunc, font, KaFontType, TthemeFuncR } from '../../styles'
 
-const StyledText = styled.div<{ type: KaFontType }>`
-  color: ${themeFunc('gray', '0')};
+type TStyledTextP = {
+  fontType: KaFontType
+  themeFuncR?: TthemeFuncR
+}
+
+const StyledText = styled.div<TStyledTextP>`
+  color: ${({ themeFuncR }) => themeFuncR ?? themeFunc('gray', '0')};
   font-stretch: normal;
   font-style: normal;
   line-height: normal;
   white-space: pre-wrap;
   word-break: break-word;
-  ${({ type }) => font[type]}
+  ${({ fontType }) => font[fontType]}
 `
 
 export type KaTextProps = {
-  fontType: KaFontType
   children: ReactNode
   color?: string
   inBorder?: boolean
-} & HTMLAttributes<HTMLDivElement>
+} & TStyledTextP &
+  HTMLAttributes<HTMLDivElement>
 
 export const KaText = ({
-  fontType,
-  children,
   color,
   inBorder = false,
   style,
   ...rest
 }: KaTextProps): ReactElement => {
-  return (
-    <StyledText
-      type={fontType}
-      style={{ color, ...style }}
-      children={children}
-      {...rest}
-    />
-  )
+  return <StyledText style={{ color, ...style }} {...rest} />
 }

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -107,13 +107,15 @@ declare module '@emotion/react' {
   export interface Theme extends KaTheme {}
 }
 
+export type TthemeFuncR = (props: { theme: KaTheme }) => string
+
 export const themeFunc =
   <T1 extends keyof KaTheme, T2 extends keyof KaTheme[T1]>(
     val1: T1,
     val2: T2,
     opacity?: number,
-  ) =>
-  ({ theme }: { theme: KaTheme }): string =>
+  ): TthemeFuncR =>
+  ({ theme }) =>
     hexToRGBA(theme[val1][val2] as string, opacity || 1)
 
 export const lightTheme = {


### PR DESCRIPTION
Currently, for styled-components to pass a theme color into KaText, a wrapper component must be used. E.g.:
```jsx
import { KaText, useKaTheme } from 'kaia-design-system'

const StyledText = styled(KaText).attrs({
  fontType: 'body/md_400'
})`
  /* other styles */
`
function StyledTextComponent({ children, ...props }) {
  const { getTheme } = useKaTheme()
  return (
    <StyledText
      color={getTheme('elevation', '3')}
      {...props}
    >
      {children}
    </StyledText>
  )
}
```

This change allows themeFunc calls to be passed directly:
```jsx
import { KaText, themeFunc } from 'kaia-design-system'

const StyledText = styled(KaText).attrs({
  fontType: 'body/md_400',
  themeFuncR: themeFunc('elevation', '3')
})`
  /* other styles */
`
```

& doesn't break existing props (color & style).