### PR TITLE
[KaSelectbox] to use reactcomponent for img

### DIFF
--- a/example/src/Home/SelectBoxes.tsx
+++ b/example/src/Home/SelectBoxes.tsx
@@ -16,7 +16,9 @@ const SelectBoxes = () => {
           {
             value: '0',
             label: 'Option 1',
-            img: 'https://square-file.qa.klaytn.net/files/profile/default.png',
+            img: (
+              <img src="https://square-file.qa.klaytn.net/files/profile/default.png" />
+            ),
           },
           { value: '1', label: 'Disabled Option2', isDisabled: true },
           { value: '2', label: 'Option 3' },
@@ -43,7 +45,9 @@ const SelectBoxes = () => {
                   {
                     value: '5',
                     label: 'More SubItem 1',
-                    img: 'https://square-file.qa.klaytn.net/files/profile/default.png',
+                    img: (
+                      <img src="https://square-file.qa.klaytn.net/files/profile/default.png" />
+                    ),
                   },
                   { value: '6', label: 'More SubItem 2' },
                 ],

--- a/src/components/SelectBox/SelectBox.tsx
+++ b/src/components/SelectBox/SelectBox.tsx
@@ -155,6 +155,7 @@ const StyledImageWrapper = styled.div`
   display: flex;
   border-radius: 50%;
   overflow: hidden;
+  object-fit: cover;
 `
 
 export interface KaSelectBoxOptionListType {
@@ -199,7 +200,7 @@ const getLabelForValue = (
 const getImgForValue = (
   options: KaSelectBoxOptionListType[],
   value: string,
-): React.ReactNode | undefined => {
+): string | ReactElement | undefined => {
   for (const option of options) {
     if (option.value === value) {
       return option.img
@@ -307,16 +308,7 @@ export const KaSelectBox = ({
             {src && (
               <StyledFormImg>
                 <StyledImageWrapper>
-                  {typeof src === 'string' ? (
-                    <img
-                      src={src}
-                      style={{
-                        objectFit: 'cover',
-                      }}
-                    />
-                  ) : (
-                    src
-                  )}
+                  {typeof src === 'string' ? <img src={src} /> : src}
                 </StyledImageWrapper>
               </StyledFormImg>
             )}
@@ -383,12 +375,7 @@ export const KaSelectBox = ({
               <StyledSelectedImg>
                 <StyledImageWrapper>
                   {typeof imgForValue === 'string' ? (
-                    <img
-                      src={imgForValue as string}
-                      style={{
-                        objectFit: 'cover',
-                      }}
-                    />
+                    <img src={imgForValue as string} />
                   ) : (
                     imgForValue
                   )}

--- a/src/components/SelectBox/SelectBox.tsx
+++ b/src/components/SelectBox/SelectBox.tsx
@@ -134,30 +134,35 @@ const NeonBar = styled.div`
   border-radius: 6px;
   justify-content: center;
 `
-type FormImgProps = {
-  src: string
-  style?: React.CSSProperties
-}
-const StyledFormImg = styled.img<FormImgProps>`
+const StyledFormImg = styled.div`
   display: inline-block;
   height: 20px;
   width: 20px;
-  border-radius: 50%;
   margin-right: 12px;
+  overflow: hidden;
 `
-const StyledSelectedImg = styled.img<FormImgProps>`
+const StyledSelectedImg = styled.div`
   display: inline-block;
   height: 34px;
   width: 34px;
   margin-right: 8px;
-  border-radius: 50%;
+  overflow: hidden;
 `
+
+const StyledImageWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  border-radius: 50%;
+  overflow: hidden;
+`
+
 export interface KaSelectBoxOptionListType {
   value: string
   label: string
   subItems?: KaSelectBoxOptionListType[]
   isDisabled?: boolean
-  img?: string
+  img?: string | ReactElement
 }
 
 export interface KaSelectBoxProps {
@@ -194,7 +199,7 @@ const getLabelForValue = (
 const getImgForValue = (
   options: KaSelectBoxOptionListType[],
   value: string,
-): string | undefined => {
+): React.ReactNode | undefined => {
   for (const option of options) {
     if (option.value === value) {
       return option.img
@@ -226,6 +231,7 @@ export const KaSelectBox = ({
 
   const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set())
   const [selected, setSelected] = useState('')
+  const imgForValue = getImgForValue(optionList, selectedValue)
 
   const toggleExpand = (value: string) => {
     setExpandedItems((prev) => {
@@ -298,7 +304,22 @@ export const KaSelectBox = ({
           <Row>
             {!isChild && isSelected && <NeonBar />}
             {indentIcon && isChild && <StyledIconindent />}
-            {src && <StyledFormImg src={src} />}
+            {src && (
+              <StyledFormImg>
+                <StyledImageWrapper>
+                  {typeof src === 'string' ? (
+                    <img
+                      src={src}
+                      style={{
+                        objectFit: 'cover',
+                      }}
+                    />
+                  ) : (
+                    src
+                  )}
+                </StyledImageWrapper>
+              </StyledFormImg>
+            )}
             <KaText
               fontType={isSelected ? 'body/md_700' : 'body/md_400'}
               color={isSelected ? getTheme('gray', '0') : getTheme('gray', '2')}
@@ -358,10 +379,21 @@ export const KaSelectBox = ({
           }}
         >
           <Row style={{ alignItems: 'center', flex: 1 }}>
-            {selectedValue && getImgForValue(optionList, selectedValue) && (
-              <StyledSelectedImg
-                src={getImgForValue(optionList, selectedValue)!}
-              />
+            {selectedValue && imgForValue && (
+              <StyledSelectedImg>
+                <StyledImageWrapper>
+                  {typeof imgForValue === 'string' ? (
+                    <img
+                      src={imgForValue as string}
+                      style={{
+                        objectFit: 'cover',
+                      }}
+                    />
+                  ) : (
+                    imgForValue
+                  )}
+                </StyledImageWrapper>
+              </StyledSelectedImg>
             )}
 
             <KaText


### PR DESCRIPTION
refactor the Kaselectbox to accept ReactElement as img instead of only accepting img url string